### PR TITLE
Fix download.sh

### DIFF
--- a/unimol_plus/scripts/download.sh
+++ b/unimol_plus/scripts/download.sh
@@ -2,6 +2,6 @@ wget http://ogb-data.stanford.edu/data/lsc/pcqm4m-v2-train.sdf.tar.gz
 md5sum pcqm4m-v2-train.sdf.tar.gz # fd72bce606e7ddf36c2a832badeec6ab
 tar -xf pcqm4m-v2-train.sdf.tar.gz # extracted pcqm4m-v2-train.sdf
 
-wget 'https://dgl-data.s3-accelerate.amazonaws.com/dataset/OGB-LSC/pcqm4m-v2.zip
+wget 'https://dgl-data.s3-accelerate.amazonaws.com/dataset/OGB-LSC/pcqm4m-v2.zip'
 unzip pcqm4m-v2.zip
 


### PR DESCRIPTION
A missing quote mark corrupts the download script.