### PR TITLE
Better UniMol+ Data Setup

### DIFF
--- a/unimol_plus/README.md
+++ b/unimol_plus/README.md
@@ -46,16 +46,17 @@ bash download.sh
 Second, covert the 3D SDF (training set only) to lmdb file:
 
 ```bash
-python get_label3d_lmdb.py
+cd pcqm4m-v2
+python ../get_label3d_lmdb.py
 ```
 
 Finally, generate the training, validation and test datasets:
 
 ```bash
-python get_3d_lmdb.py train
-python get_3d_lmdb.py valid
-python get_3d_lmdb.py test-dev
-python get_3d_lmdb.py test-challenge
+python ../get_3d_lmdb.py train
+python ../get_3d_lmdb.py valid
+python ../get_3d_lmdb.py test-dev
+python ../get_3d_lmdb.py test-challenge
 ```
 
 #### OC20

--- a/unimol_plus/scripts/download.sh
+++ b/unimol_plus/scripts/download.sh
@@ -4,4 +4,4 @@ tar -xf pcqm4m-v2-train.sdf.tar.gz # extracted pcqm4m-v2-train.sdf
 
 wget 'https://dgl-data.s3-accelerate.amazonaws.com/dataset/OGB-LSC/pcqm4m-v2.zip'
 unzip pcqm4m-v2.zip
-
+mv pcqm4m-v2-train.sdf pcqm4m-v2

--- a/unimol_plus/scripts/get_3d_lmdb.py
+++ b/unimol_plus/scripts/get_3d_lmdb.py
@@ -17,7 +17,7 @@ split_key = sys.argv[1]
 split = torch.load("split_dict.pt")
 valid_index = split[split_key]
 
-lines = gzip.open("data.csv.gz", "r").readlines()
+lines = gzip.open("raw/data.csv.gz", "r").readlines()
 
 target = []
 smiles = []


### PR DESCRIPTION
Added minor path corrections to data setup instructions so they can be executed by just following the instructions. 

The resulting `.lmdb` files used for training the PCQM4MV2 task will be in `Uni-Mol/unimol_plus/scripts/pcqm4m-v2`