### PR TITLE
Update Uni-Mol+ Dependencies

### DIFF
--- a/unimol_plus/README.md
+++ b/unimol_plus/README.md
@@ -28,6 +28,7 @@ Dependencies
 ------------
  - [Uni-Core](https://github.com/dptech-corp/Uni-Core) with pytorch > 2.0.0, check its [Installation Documentation](https://github.com/dptech-corp/Uni-Core#installation).
  - rdkit==2022.09.3, install via `pip install rdkit==2022.09.3`
+ - numba and pandas, install via `pip install numba pandas`
 
 
 Data Preparation


### PR DESCRIPTION
Missing two dependencies, users cannot run this project correctly without these dependencies after installing Uni-Core and RDKit.