### PR TITLE
Disable batch shuffling. Only per sample

### DIFF
--- a/unimol/unimol/tasks/unimol.py
+++ b/unimol/unimol/tasks/unimol.py
@@ -235,3 +235,7 @@ class UniMolTask(UnicoreTask):
 
         model = models.build_model(args, self)
         return model
+
+    def disable_shuffling(self) -> bool:
+        return True
+    


### PR DESCRIPTION
Currently batch size will affect the order of samples, therefore can't adjust the effective batch_size (`num_gpus * batch_size * update_freq`) and keep the same results. 

See for context: https://github.com/dptech-corp/Uni-Core/pull/39