### PR TITLE
fix multilabel datareader bug

### DIFF
--- a/unimol_tools/unimol_tools/data/datareader.py
+++ b/unimol_tools/unimol_tools/data/datareader.py
@@ -65,9 +65,10 @@ class MolDataReader(object):
                 else:
                     for i in range(label.shape[1]):
                         data[target_col_prefix + str(i)] = label[:,i]
+
+            _ = data.pop('target')
             data = pd.DataFrame(data).rename(columns={smiles_col: 'SMILES'})
-            if 'target' in data:
-                data = data.drop(columns=['target'])
+        
         elif isinstance(data, list):
             # load from smiles list
             data = pd.DataFrame(data, columns=['SMILES'])


### PR DESCRIPTION
Demo
```python
from unimol_tools import MolTrain
import numpy as np
custom_data ={'target':np.random.randint(2, size=(100, 10)),  # multilabel
            'atoms':[['C','C','H','H','H','H'] for _ in range(100)],
            'coordinates':[np.random.randn(6,3) for _ in range(100)],
            }

clf = MolTrain(
    task = 'multilabel_classification',
    save_path = 'tmp_exp'
    )
clf.fit(custom_data)
```
_ValueError: Per-column arrays must each be 1-dimensional_